### PR TITLE
Receive multiple messages

### DIFF
--- a/Emotilt/Emotilt.xcodeproj/project.pbxproj
+++ b/Emotilt/Emotilt.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		B8E7E25829AC8ADA0046D98E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B8E7E25729AC8ADA0046D98E /* Assets.xcassets */; };
 		B8E7E25B29AC8ADA0046D98E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B8E7E25A29AC8ADA0046D98E /* Preview Assets.xcassets */; };
 		B8E7E26729AC8C690046D98E /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E7E26629AC8C690046D98E /* Message.swift */; };
+		B8F22B9729B7473E00FAE9F9 /* EmojiSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F22B9629B7473E00FAE9F9 /* EmojiSheet.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +42,7 @@
 		B8E7E26129AC8BAD0046D98E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B8E7E26629AC8C690046D98E /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		B8F22B9529B7117B00FAE9F9 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		B8F22B9629B7473E00FAE9F9 /* EmojiSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiSheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,6 +113,7 @@
 				B8E7E25529AC8AD90046D98E /* HomeView.swift */,
 				B86014A729B1BE3100C27112 /* RoundedButton.swift */,
 				B86014A929B1BE6D00C27112 /* MessagePopupView.swift */,
+				B8F22B9629B7473E00FAE9F9 /* EmojiSheet.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -211,6 +214,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B8F22B9729B7473E00FAE9F9 /* EmojiSheet.swift in Sources */,
 				B86014AC29B1D03B00C27112 /* Float+ext.swift in Sources */,
 				B8E7E26729AC8C690046D98E /* Message.swift in Sources */,
 				B86014A829B1BE3100C27112 /* RoundedButton.swift in Sources */,

--- a/Emotilt/Emotilt.xcodeproj/project.pbxproj
+++ b/Emotilt/Emotilt.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		B86014AA29B1BE6D00C27112 /* MessagePopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86014A929B1BE6D00C27112 /* MessagePopupView.swift */; };
 		B86014AC29B1D03B00C27112 /* Float+ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86014AB29B1D03B00C27112 /* Float+ext.swift */; };
 		B8E7E25429AC8AD90046D98E /* EmotiltApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E7E25329AC8AD90046D98E /* EmotiltApp.swift */; };
-		B8E7E25629AC8AD90046D98E /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E7E25529AC8AD90046D98E /* HomeView.swift */; };
+		B8E7E25629AC8AD90046D98E /* HomeScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E7E25529AC8AD90046D98E /* HomeScene.swift */; };
 		B8E7E25829AC8ADA0046D98E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B8E7E25729AC8ADA0046D98E /* Assets.xcassets */; };
 		B8E7E25B29AC8ADA0046D98E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B8E7E25A29AC8ADA0046D98E /* Preview Assets.xcassets */; };
 		B8E7E26729AC8C690046D98E /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E7E26629AC8C690046D98E /* Message.swift */; };
@@ -36,7 +36,7 @@
 		B86014AB29B1D03B00C27112 /* Float+ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Float+ext.swift"; sourceTree = "<group>"; };
 		B8E7E25029AC8AD90046D98E /* Emotilt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Emotilt.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8E7E25329AC8AD90046D98E /* EmotiltApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmotiltApp.swift; sourceTree = "<group>"; };
-		B8E7E25529AC8AD90046D98E /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		B8E7E25529AC8AD90046D98E /* HomeScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScene.swift; sourceTree = "<group>"; };
 		B8E7E25729AC8ADA0046D98E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B8E7E25A29AC8ADA0046D98E /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		B8E7E26129AC8BAD0046D98E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -110,7 +110,7 @@
 		B8E7E26229AC8C360046D98E /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				B8E7E25529AC8AD90046D98E /* HomeView.swift */,
+				B8E7E25529AC8AD90046D98E /* HomeScene.swift */,
 				B86014A729B1BE3100C27112 /* RoundedButton.swift */,
 				B86014A929B1BE6D00C27112 /* MessagePopupView.swift */,
 				B8F22B9629B7473E00FAE9F9 /* EmojiSheet.swift */,
@@ -222,7 +222,7 @@
 				B860149929AE3F5C00C27112 /* MPCSessionManager.swift in Sources */,
 				B86014A129AE5E3400C27112 /* HomeViewModel.swift in Sources */,
 				B86014AA29B1BE6D00C27112 /* MessagePopupView.swift in Sources */,
-				B8E7E25629AC8AD90046D98E /* HomeView.swift in Sources */,
+				B8E7E25629AC8AD90046D98E /* HomeScene.swift in Sources */,
 				B86014A629B1A72700C27112 /* BaseViewModel.swift in Sources */,
 				B860149D29AE549C00C27112 /* PeerSessionManager.swift in Sources */,
 				B86014A429B19B3000C27112 /* Configuration.swift in Sources */,

--- a/Emotilt/Emotilt/EmotiltApp.swift
+++ b/Emotilt/Emotilt/EmotiltApp.swift
@@ -19,7 +19,7 @@ struct EmotiltApp: App {
     
     var body: some Scene {
         WindowGroup {
-            HomeView(viewModel: .init(peerSessionManager: peerSessionManager))
+            HomeScene(viewModel: .init(peerSessionManager: peerSessionManager))
         }
     }
 }

--- a/Emotilt/Emotilt/Models/Message.swift
+++ b/Emotilt/Emotilt/Models/Message.swift
@@ -11,3 +11,9 @@ struct Message: Codable {
     let emoji: String
     let content: String?
 }
+
+/// Contains `sender` information
+struct MessageMetaData: Codable {
+    let sender: String
+    let message: Message
+}

--- a/Emotilt/Emotilt/Network/MPCSessionManager.swift
+++ b/Emotilt/Emotilt/Network/MPCSessionManager.swift
@@ -77,7 +77,9 @@ class MPCSessionManager: NSObject {
             return
         }
         
-        guard let data = try? JSONEncoder().encode(message) else {
+        let messageMetaData = MessageMetaData(sender: session.myPeerID.displayName, message: message)
+        
+        guard let data = try? JSONEncoder().encode(messageMetaData) else {
             // fail to encode Message into data
             return
         }

--- a/Emotilt/Emotilt/Network/PeerSessionManager.swift
+++ b/Emotilt/Emotilt/Network/PeerSessionManager.swift
@@ -17,7 +17,7 @@ class PeerSessionManager: NSObject {
     @Published var peerList: [Peer] = []
     
     /// 수신한 메시지
-    @Published var receivedMessage: MessageMetaData?
+    @Published var receivedMessage: [MessageMetaData] = []
     
     /// 현재 내 로컬 디바이스와 가장 가까이 있는 기기의 discoveryToken
     @Published var nearestPeerToken: NIDiscoveryToken?
@@ -48,7 +48,7 @@ class PeerSessionManager: NSObject {
             if let discoveryToken = try? NSKeyedUnarchiver.unarchivedObject(ofClass: NIDiscoveryToken.self, from: received.1) {
                 self?.receivedDiscoveryToken(from: received.0, token: discoveryToken)
             } else if let messageMetaData = try? JSONDecoder().decode(MessageMetaData.self, from: received.1) {
-                self?.receivedMessage = messageMetaData
+                self?.receivedMessage.append(messageMetaData)
             }
         }.store(in: &bag)
     }
@@ -66,6 +66,12 @@ class PeerSessionManager: NSObject {
         }
         
         mpcSessionManager.sendMessage(message, to: peerID)
+    }
+    
+    func removeFirstMessage() {
+        if !receivedMessage.isEmpty {
+            _ = receivedMessage.removeFirst()
+        }
     }
     
     /// 새로운 Peer를 추가하고 연결받을 준비를 합니다.

--- a/Emotilt/Emotilt/Network/PeerSessionManager.swift
+++ b/Emotilt/Emotilt/Network/PeerSessionManager.swift
@@ -17,7 +17,7 @@ class PeerSessionManager: NSObject {
     @Published var peerList: [Peer] = []
     
     /// 수신한 메시지
-    @Published var receivedMessage: Message?
+    @Published var receivedMessage: MessageMetaData?
     
     /// 현재 내 로컬 디바이스와 가장 가까이 있는 기기의 discoveryToken
     @Published var nearestPeerToken: NIDiscoveryToken?
@@ -47,8 +47,8 @@ class PeerSessionManager: NSObject {
         mpcSessionManager.$received.compactMap { $0 }.receive(on: RunLoop.main).sink { [weak self] received in
             if let discoveryToken = try? NSKeyedUnarchiver.unarchivedObject(ofClass: NIDiscoveryToken.self, from: received.1) {
                 self?.receivedDiscoveryToken(from: received.0, token: discoveryToken)
-            } else if let message = try? JSONDecoder().decode(Message.self, from: received.1) {
-                self?.receivedMessage = message
+            } else if let messageMetaData = try? JSONDecoder().decode(MessageMetaData.self, from: received.1) {
+                self?.receivedMessage = messageMetaData
             }
         }.store(in: &bag)
     }
@@ -102,7 +102,7 @@ class PeerSessionManager: NSObject {
     }
     
     private func deleteUnconnectedPeer(_ peerID: MCPeerID) {
-        peerList.removeAll(where: { $0.id == peerID })
+        peerList.removeAll(where: { $0.id == peerID && $0.session.configuration != nil })
     }
     
     /// Session을 열어둔 상태에서 token을 받은 경우

--- a/Emotilt/Emotilt/ViewModels/HomeViewModel.swift
+++ b/Emotilt/Emotilt/ViewModels/HomeViewModel.swift
@@ -12,22 +12,26 @@ class HomeViewModel: BaseViewModel, ObservableObject {
     @Published var peerList: [Peer] = []
     
     /// 수신한 메시지
-    @Published var receivedMessage: MessageMetaData?
+    @Published var receivedMessageList: [MessageMetaData] = []
     
     /// close-only
     var didReceiveMessage: Bool {
-        get { receivedMessage != nil }
-        set { receivedMessage = nil }
+        get { !receivedMessageList.isEmpty }
+        set { removeFirstMessage() }
     }
     
     override init(peerSessionManager: PeerSessionManager) {
         super.init(peerSessionManager: peerSessionManager)
         
         peerSessionManager.$peerList.assign(to: &$peerList)
-        peerSessionManager.$receivedMessage.assign(to: &$receivedMessage)
+        peerSessionManager.$receivedMessage.assign(to: &$receivedMessageList)
     }
     
     func sendMessage(_ message: Message) {
         peerSessionManager.sendMessageToNearestPeer(message)
+    }
+    
+    private func removeFirstMessage() {
+        peerSessionManager.removeFirstMessage()
     }
 }

--- a/Emotilt/Emotilt/ViewModels/HomeViewModel.swift
+++ b/Emotilt/Emotilt/ViewModels/HomeViewModel.swift
@@ -12,10 +12,12 @@ class HomeViewModel: BaseViewModel, ObservableObject {
     @Published var peerList: [Peer] = []
     
     /// 수신한 메시지
-    @Published var receivedMessage: Message?
+    @Published var receivedMessage: MessageMetaData?
     
+    /// close-only
     var didReceiveMessage: Bool {
-        receivedMessage != nil
+        get { receivedMessage != nil }
+        set { receivedMessage = nil }
     }
     
     override init(peerSessionManager: PeerSessionManager) {

--- a/Emotilt/Emotilt/Views/EmojiSheet.swift
+++ b/Emotilt/Emotilt/Views/EmojiSheet.swift
@@ -1,0 +1,49 @@
+//
+//  EmojiSheet.swift
+//  Emotilt
+//
+//  Created by 최유림 on 2023/03/07.
+//
+
+import SwiftUI
+
+struct EmojiSheet: View {
+    
+    @Binding var selected: String
+    
+    @Environment(\.dismiss) private var dismiss
+    
+    let emojiList: [Int] = Array(0x1F600...0x1F64F)
+    let layout = [GridItem(.flexible(), spacing: 16),
+                  GridItem(.flexible(), spacing: 16),
+                  GridItem(.flexible(), spacing: 16),
+                  GridItem(.flexible())]
+    
+    var body: some View {
+        VStack {
+            Spacer().frame(height: 36)
+
+            ScrollView {
+                LazyVGrid(columns: layout, spacing: 16) {
+                    ForEach(emojiList, id: \.self) { emoji in
+                        if let _ = UnicodeScalar(emoji)?.properties.isEmoji {
+                            Text(String(UnicodeScalar(emoji)!))
+                                .font(.system(size: 32))
+                                .onTapGesture {
+                                    selected = String(UnicodeScalar(emoji)!)
+                                    dismiss()
+                                }
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+    }
+}
+
+struct EmojiSheet_Previews: PreviewProvider {
+    static var previews: some View {
+        EmojiSheet(selected: .constant(""))
+    }
+}

--- a/Emotilt/Emotilt/Views/HomeScene.swift
+++ b/Emotilt/Emotilt/Views/HomeScene.swift
@@ -1,5 +1,5 @@
 //
-//  HomeView.swift
+//  HomeScene.swift
 //  Emotilt
 //
 //  Created by 최유림 on 2023/02/27.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct HomeView: View {
+struct HomeScene: View {
     
     @ObservedObject var viewModel: HomeViewModel
     
@@ -42,7 +42,7 @@ struct HomeView: View {
             Spacer()
             
             RoundedButton(label: "Send") {
-                viewModel.sendMessage(.init(emoji: "🤔", content: "Nyam"))
+                viewModel.sendMessage(.init(emoji: "🤔", content: "Nyam \(Int.random(in: 0...20))"))
             }
             
             Spacer().frame(height: 16)
@@ -52,8 +52,8 @@ struct HomeView: View {
             EmojiSheet(selected: $emoji)
         }
         .sheet(isPresented: $viewModel.didReceiveMessage) {
-            if let messageMetaData = viewModel.receivedMessage {
-                MessagePopupView(messageMetaData: messageMetaData)
+            if let messageMetaData = viewModel.receivedMessageList.first {
+                MessagePopupView(messageMetaData: messageMetaData, leftCount: $viewModel.receivedMessageList.count)
             }
         }
     }
@@ -61,6 +61,6 @@ struct HomeView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        HomeView(viewModel: .init(peerSessionManager: .debug))
+        HomeScene(viewModel: .init(peerSessionManager: .debug))
     }
 }

--- a/Emotilt/Emotilt/Views/HomeView.swift
+++ b/Emotilt/Emotilt/Views/HomeView.swift
@@ -17,17 +17,27 @@ struct HomeView: View {
     
     var body: some View {
         VStack(alignment: .center) {
+            Spacer()
+            
+            if emoji.isEmpty {
+                Button {
+                    isEmojiSheetOpen = true
+                } label: {
+                    RoundedRectangle(cornerRadius: 32)
+                        .fill(.tertiary.opacity(0.4))
+                        .frame(width: 168, height: 168)
+                }
+            } else {
+                Text(emoji)
+                    .font(.system(size: 168))
+            }
+            
             Spacer().frame(height: 24)
             
-            if let message = viewModel.receivedMessage {
-                Text(message.emoji)
-                    .font(.system(size: 42))
-                
-                Spacer().frame(height: 16)
-                
-                Text(message.content ?? "")
-                    .font(.system(size: 36))
-            }
+            TextField("", text: $content, prompt: Text("20자 이내"))
+                .font(.system(size: 24, weight: .bold))
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
             
             Spacer()
             
@@ -38,6 +48,14 @@ struct HomeView: View {
             Spacer().frame(height: 16)
         }
         .padding(.horizontal, 36)
+        .sheet(isPresented: $isEmojiSheetOpen) {
+            EmojiSheet(selected: $emoji)
+        }
+        .sheet(isPresented: $viewModel.didReceiveMessage) {
+            if let messageMetaData = viewModel.receivedMessage {
+                MessagePopupView(messageMetaData: messageMetaData)
+            }
+        }
     }
 }
 

--- a/Emotilt/Emotilt/Views/MessagePopupView.swift
+++ b/Emotilt/Emotilt/Views/MessagePopupView.swift
@@ -8,19 +8,31 @@
 import SwiftUI
 
 struct MessagePopupView: View {
-    let message: Message
-    @Binding var isPopupViewPresented: Bool
+    let messageMetaData: MessageMetaData
+    
+    @Environment(\.dismiss) private var dismiss
     
     var body: some View {
         VStack {
+            Spacer().frame(height: 32)
+            
+            Group {
+                Text("From")
+                    .font(.system(size: 24, weight: .semibold))
+                
+                Spacer().frame(height: 8)
+                
+                Text(messageMetaData.sender)
+            }
+            
             Spacer()
             
-            Text(message.emoji)
+            Text(messageMetaData.message.emoji)
                 .font(.system(size: 168))
             
             Spacer().frame(height: 24)
             
-            if let content = message.content {
+            if let content = messageMetaData.message.content {
                 Text(content)
                     .font(.system(size: 36, weight: .bold))
                     .multilineTextAlignment(.center)
@@ -30,17 +42,17 @@ struct MessagePopupView: View {
             Spacer()
             
             RoundedButton(label: "Close") {
-                isPopupViewPresented = false
+                dismiss()
             }
             .padding(.horizontal, 60)
             
-            Spacer().frame(height: 16)
+            Spacer().frame(height: 24)
         }
     }
 }
 
 struct MessagePopupView_Previews: PreviewProvider {
     static var previews: some View {
-        MessagePopupView(message: .init(emoji: "🤔", content: "waffle!"), isPopupViewPresented: .constant(true))
+        MessagePopupView(messageMetaData: .init(sender: "와플's iPhone", message: .init(emoji: "🤔", content: "waffle!")))
     }
 }

--- a/Emotilt/Emotilt/Views/MessagePopupView.swift
+++ b/Emotilt/Emotilt/Views/MessagePopupView.swift
@@ -9,12 +9,15 @@ import SwiftUI
 
 struct MessagePopupView: View {
     let messageMetaData: MessageMetaData
+    let leftCount: Int
     
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
         VStack {
             Spacer().frame(height: 32)
+            
+            Text("\(leftCount) messages left")
             
             Group {
                 Text("From")
@@ -53,6 +56,6 @@ struct MessagePopupView: View {
 
 struct MessagePopupView_Previews: PreviewProvider {
     static var previews: some View {
-        MessagePopupView(messageMetaData: .init(sender: "와플's iPhone", message: .init(emoji: "🤔", content: "waffle!")))
+        MessagePopupView(messageMetaData: .init(sender: "와플's iPhone", message: .init(emoji: "🤔", content: "waffle!")), leftCount: 3)
     }
 }


### PR DESCRIPTION
### 수정사항
- 메시지를 보낼 때 발신자 정보(디바이스 이름)를 포함하도록 `MessageMetaData`를 추가
- `MessagePopupView`에 밀린 메시지 개수를 확인하는 UI 추가